### PR TITLE
SRP-1359 ClaudFlare/Varnish adapter

### DIFF
--- a/Config/CacheConfig.php
+++ b/Config/CacheConfig.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Config;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\StoreManagerInterface;
+
+class CacheConfig extends \SR\Gateway\Model\Config\Config
+{
+    public const EXT_ALIAS = 'srcloudflare';
+    public const DEFAULT_PATH_GROUP = 'cache';
+
+    private const KEY_ZONE_ID = 'zone_id';
+    private const KEY_API_TOKEN = 'api_token';
+    private const KEY_API_URL = 'api_url';
+
+    private ?string $siteTag = null;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        private readonly StoreManagerInterface $storeManager,
+        string $pathPattern = self::EXT_ALIAS . '/%s/%s'
+    ) {
+        parent::__construct($scopeConfig, $pathPattern);
+    }
+
+    public function isActive(): bool
+    {
+        return (bool) $this->getValue(self::KEY_CONFIG_ACTIVE, self::DEFAULT_PATH_GROUP);
+    }
+
+    public function getZoneId(): ?string
+    {
+        return $this->getValue(self::KEY_ZONE_ID, self::DEFAULT_PATH_GROUP);
+    }
+
+    public function getApiToken(): ?string
+    {
+        return $this->getValue(self::KEY_API_TOKEN, self::DEFAULT_PATH_GROUP);
+    }
+
+    public function getApiUrl(): ?string
+    {
+        return $this->getValue(self::KEY_API_URL, self::DEFAULT_PATH_GROUP);
+    }
+
+    public function isDebugEnabled(): bool
+    {
+        return (bool) $this->getValue(self::KEY_CONFIG_DEBUG, self::DEFAULT_PATH_GROUP);
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->isActive()
+            && !empty($this->getZoneId())
+            && !empty($this->getApiToken());
+    }
+
+    public function getResolvedApiUrl(): string
+    {
+        return sprintf((string) $this->getApiUrl(), (string) $this->getZoneId());
+    }
+
+    /**
+     * Get hostname-based site-wide tag used for full cache flush
+     * and to scope tags per site when multiple sites share the same Cloudflare zone.
+     *
+     * e.g. "all4pet.mystore.today" → "all4pet_mystore_today"
+     */
+    public function getSiteTag(): string
+    {
+        if ($this->siteTag === null) {
+            try {
+                $baseUrl = $this->storeManager->getStore()->getBaseUrl();
+                $host = (string) parse_url($baseUrl, PHP_URL_HOST);
+                $this->siteTag = str_replace(['.', '-'], '_', $host);
+            } catch (\Exception) {
+                $this->siteTag = 'default';
+            }
+        }
+
+        return $this->siteTag;
+    }
+}

--- a/Model/CloudflareClient.php
+++ b/Model/CloudflareClient.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Model;
+
+use Laminas\Http\Request as HttpRequest;
+use SR\Gateway\Api\Http\Client\ClientInterface;
+use SR\Gateway\Api\LoggerInterface;
+use SR\Gateway\Model\Http\TransferBuilderFactory;
+
+class CloudflareClient
+{
+    private const MAX_TAGS_PER_REQUEST = 30;
+
+    public function __construct(
+        private readonly \SR\Cloudflare\Config\CacheConfig $config,
+        private readonly ClientInterface                  $restClient,
+        private readonly TransferBuilderFactory           $transferBuilderFactory,
+        private readonly LoggerInterface                  $logger
+    ) {
+    }
+
+    /**
+     * Purge cached pages by cache tags.
+     *
+     * @param string[] $tags
+     */
+    public function purgeByTags(array $tags): void
+    {
+        $tags = array_values(array_unique($tags));
+
+        if (empty($tags)) {
+            return;
+        }
+
+        foreach (array_chunk($tags, self::MAX_TAGS_PER_REQUEST) as $batch) {
+            $this->sendPurgeRequest(['tags' => $batch]);
+        }
+    }
+
+    /**
+     * Purge all cached pages by site-wide tag (hostname).
+     *
+     * Uses tag-based purge instead of purge_everything
+     * to avoid clearing Cloudflare Image Transformations cache.
+     */
+    public function purgeAll(): void
+    {
+        $siteTag = $this->config->getSiteTag();
+        $this->sendPurgeRequest(['tags' => [$siteTag]]);
+    }
+
+    /**
+     * Purge cached pages by URLs (fallback method).
+     *
+     * @param string[] $urls
+     */
+    public function purgeByUrls(array $urls): void
+    {
+        $urls = array_values(array_unique($urls));
+
+        if (empty($urls)) {
+            return;
+        }
+
+        foreach (array_chunk($urls, self::MAX_TAGS_PER_REQUEST) as $batch) {
+            $this->sendPurgeRequest(['files' => $batch]);
+        }
+    }
+
+    private function sendPurgeRequest(array $body): void
+    {
+        if (!$this->config->isConfigured()) {
+            return;
+        }
+
+        $url = $this->config->getResolvedApiUrl();
+
+        try {
+            $transfer = $this->transferBuilderFactory->create()
+                ->setMethod(HttpRequest::METHOD_POST)
+                ->setUri($url)
+                ->setHeaders([
+                    'Authorization' => 'Bearer ' . $this->config->getApiToken(),
+                    'Content-Type'  => 'application/json',
+                ])
+                ->setBody($body)
+                ->shouldEncode(true)
+                ->build();
+
+            $this->restClient->placeRequest($transfer);
+        } catch (\Exception $e) {
+            $this->logger->error(
+                'SR_Cloudflare: Purge API request failed: ' . $e->getMessage()
+            );
+        }
+    }
+}

--- a/Model/Logger/Handler/CacheFileHandler.php
+++ b/Model/Logger/Handler/CacheFileHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Model\Logger\Handler;
+
+use Magento\Framework\Filesystem\DriverInterface;
+use Magento\Framework\Logger\Handler\Debug as LoggerDebugHandler;
+use SR\Gateway\Api\Config\ConfigInterface;
+use SR\Gateway\Model\Config\Config;
+
+/**
+ * File handler that reads active/debug flags from the 'cache' config group
+ * instead of the hardcoded 'general' used by the Gateway base FileHandler.
+ */
+class CacheFileHandler extends LoggerDebugHandler
+{
+    private const CONFIG_GROUP = 'cache';
+
+    protected ConfigInterface $config;
+
+    public function __construct(
+        DriverInterface $filesystem,
+        ConfigInterface $config,
+        ?string $filePath = null,
+        ?string $fileName = null
+    ) {
+        $this->config = $config;
+
+        parent::__construct($filesystem, $filePath, $fileName);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isHandling($record): bool
+    {
+        if (!$this->config->getValue(Config::KEY_CONFIG_ACTIVE, self::CONFIG_GROUP)) {
+            return false;
+        }
+
+        if (!parent::isHandling($record)) {
+            return false;
+        }
+
+        return (bool) $this->config->getValue(Config::KEY_CONFIG_DEBUG, self::CONFIG_GROUP);
+    }
+}

--- a/Observer/FlushAllCacheObserver.php
+++ b/Observer/FlushAllCacheObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Observer;
+
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use SR\Cloudflare\Model\CloudflareClient;
+use SR\Cloudflare\Config\CacheConfig;
+
+class FlushAllCacheObserver implements ObserverInterface
+{
+    public function __construct(
+        private readonly CloudflareClient $cloudflareClient,
+        private readonly CacheConfig $config
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        if (!$this->config->isConfigured()) {
+            return;
+        }
+
+        $this->cloudflareClient->purgeAll();
+    }
+}

--- a/Observer/PurgeByTags.php
+++ b/Observer/PurgeByTags.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Observer;
+
+use Magento\Framework\App\Cache\Tag\Resolver;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use SR\Cloudflare\Model\CloudflareClient;
+use SR\Cloudflare\Config\CacheConfig;
+
+class PurgeByTags implements ObserverInterface
+{
+    public function __construct(
+        private readonly CloudflareClient $cloudflareClient,
+        private readonly Resolver $tagResolver,
+        private readonly CacheConfig $config
+    ) {
+    }
+
+    public function execute(Observer $observer): void
+    {
+        if (!$this->config->isConfigured()) {
+            return;
+        }
+
+        $object = $observer->getEvent()->getObject();
+
+        if (!is_object($object)) {
+            return;
+        }
+
+        $tags = $this->tagResolver->getTags($object);
+
+        if (!empty($tags)) {
+            $this->cloudflareClient->purgeByTags(array_unique($tags));
+        }
+    }
+}

--- a/Plugin/AddCacheTagHeader.php
+++ b/Plugin/AddCacheTagHeader.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SR\Cloudflare\Plugin;
+
+use Magento\Framework\App\Response\Http;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\ResultInterface;
+use SR\Cloudflare\Config\CacheConfig;
+
+class AddCacheTagHeader
+{
+    public function __construct(
+        private readonly CacheConfig $config
+    ) {
+    }
+
+    /**
+     * Copy X-Magento-Tags into Cache-Tag header with a site-wide tag prepended.
+     *
+     * Runs before Magento's BuiltinPlugin/VarnishPlugin (sortOrder=-10 vs their default 0)
+     * so the header is captured before Kernel::process() clears X-Magento-Tags.
+     *
+     * The site-wide tag (hostname) enables full-cache flush by tag
+     * without purge_everything (which would also wipe Image Transformations cache).
+     */
+    public function afterRenderResult(
+        ResultInterface $subject,
+        ResultInterface $result,
+        ResponseInterface $response
+    ): ResultInterface {
+        if (!$response instanceof Http) {
+            return $result;
+        }
+
+        $magentoTags = $response->getHeader('X-Magento-Tags');
+
+        if (!$magentoTags) {
+            return $result;
+        }
+
+        $value = is_object($magentoTags) ? $magentoTags->getFieldValue() : (string) $magentoTags;
+
+        if ($value === '') {
+            return $result;
+        }
+
+        $tags = explode(',', $value);
+        array_unshift($tags, $this->config->getSiteTag());
+        $response->setHeader('Cache-Tag', implode(',', $tags));
+
+        return $result;
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -31,6 +31,44 @@
                     <comment><![CDATA[Affects interpretation of <i>width</i> and <i>height</i>. All resizing modes preserve aspect ratio.<br>See <a href="https://developers.cloudflare.com/images/image-resizing/url-format/#fit" target="_blank">Cloudflare documentation</a> for more information.]]></comment>
                 </field>
             </group>
+
+            <group id="cache" translate="label" type="text" sortOrder="10"
+                   showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Cloudflare Cache</label>
+
+                <field id="active" translate="label" sortOrder="10" type="select"
+                       showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Enabled</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+
+                <field id="zone_id" translate="label comment" sortOrder="20" type="text"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>Zone ID</label>
+                    <comment><![CDATA[Cloudflare Zone ID from the dashboard Overview page.]]></comment>
+                    <validate>required-entry</validate>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+
+                <field id="api_token" translate="label comment" sortOrder="30" type="obscure"
+                       showInDefault="1" showInWebsite="0" showInStore="0">
+                    <label>API Token</label>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
+                    <comment><![CDATA[Cloudflare API Token with <strong>Zone.Cache Purge</strong> permission.]]></comment>
+                    <depends>
+                        <field id="active">1</field>
+                    </depends>
+                </field>
+
+                <field id="debug" translate="label comment" sortOrder="100" type="select"
+                       showInDefault="1" showInWebsite="0" showInStore="0" canRestore="1">
+                    <label>Debug</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[When enabled, API requests and responses are written to <code>var/log/srcloudflarecache.log</code>]]></comment>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,6 +11,12 @@
                 <image_quality>85</image_quality>
                 <image_fit>none</image_fit>
             </general>
+            <cache>
+                <active>0</active>
+                <debug>0</debug>
+                <api_url>https://api.cloudflare.com/client/v4/zones/%s/purge_cache</api_url>
+                <api_token backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
+            </cache>
         </srcloudflare>
     </default>
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -15,4 +15,69 @@
 <!--    </type>-->
     <virtualType name="SrCloudflareModuleState" type="SR\Cloudflare\Config\ModuleState" />
 <!-- end: Extension Activity STATE -->
+
+    <!-- Config -->
+    <virtualType name="SrCloudflareCacheConfig" type="SR\Cloudflare\Config\CacheConfig"/>
+
+    <!-- Logger -->
+    <virtualType name="SrCloudflareCacheMainLogger" type="SR\Gateway\Model\Logger">
+        <arguments>
+            <argument name="logger" xsi:type="object">SrCloudflareCacheBaseLogger</argument>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="SrCloudflareCacheBaseLogger" type="SR\Gateway\Model\Logger\Logger">
+        <arguments>
+            <argument name="name" xsi:type="string">srcloudflarecache</argument>
+            <argument name="handlers" xsi:type="array">
+                <item name="file" xsi:type="object">SrCloudflareCacheLoggerFileHandler</item>
+            </argument>
+        </arguments>
+    </virtualType>
+
+    <virtualType name="SrCloudflareCacheLoggerFileHandler" type="SR\Cloudflare\Model\Logger\Handler\CacheFileHandler">
+        <arguments>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+            <argument name="fileName" xsi:type="string">var/log/srcloudflarecache.log</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- REST client -->
+    <virtualType name="SrCloudflareCacheRestClient" type="SR\Gateway\Model\Http\Client\Rest">
+        <arguments>
+            <argument name="logger" xsi:type="object">SrCloudflareCacheMainLogger</argument>
+            <argument name="converter" xsi:type="object">SR\Gateway\Model\Http\Client\Converter\ObjectToArrayRestConverter</argument>
+        </arguments>
+    </virtualType>
+
+    <!-- CloudflareClient -->
+    <type name="SR\Cloudflare\Model\CloudflareClient">
+        <arguments>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+            <argument name="restClient" xsi:type="object">SrCloudflareCacheRestClient</argument>
+            <argument name="logger" xsi:type="object">SrCloudflareCacheMainLogger</argument>
+        </arguments>
+    </type>
+
+    <!-- Observer -->
+    <type name="SR\Cloudflare\Observer\PurgeByTags">
+        <arguments>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+        </arguments>
+    </type>
+
+    <!-- FlushAllCacheObserver -->
+    <type name="SR\Cloudflare\Observer\FlushAllCacheObserver">
+        <arguments>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+        </arguments>
+    </type>
+
+    <!-- Plugin -->
+    <type name="SR\Cloudflare\Plugin\AddCacheTagHeader">
+        <arguments>
+            <argument name="config" xsi:type="object">SrCloudflareCacheConfig</argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="clean_cache_by_tags">
+        <observer name="sr_cloudflare_purge_by_tags"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="assigned_theme_changed">
+        <observer name="sr_cloudflare_purge_by_tags_theme_changed"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="catalogrule_after_apply">
+        <observer name="sr_cloudflare_purge_by_tags_catalogrule"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="controller_action_postdispatch_adminhtml_system_currency_saveRates">
+        <observer name="sr_cloudflare_purge_by_tags_currency_rates"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="controller_action_postdispatch_adminhtml_system_config_save">
+        <observer name="sr_cloudflare_purge_by_tags_config_save"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="controller_action_postdispatch_adminhtml_catalog_product_action_attribute_save">
+        <observer name="sr_cloudflare_purge_by_tags_product_attribute_save"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="controller_action_postdispatch_adminhtml_catalog_product_massStatus">
+        <observer name="sr_cloudflare_purge_by_tags_product_mass_status"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="controller_action_postdispatch_adminhtml_system_currencysymbol_save">
+        <observer name="sr_cloudflare_purge_by_tags_currency_symbol"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="clean_cache_after_reindex">
+        <observer name="sr_cloudflare_purge_by_tags_after_reindex"
+                  instance="SR\Cloudflare\Observer\PurgeByTags"/>
+    </event>
+    <event name="adminhtml_cache_flush_system">
+        <observer name="sr_cloudflare_flush_all_on_flush_system"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="adminhtml_cache_flush_all">
+        <observer name="sr_cloudflare_flush_all_on_flush_all"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="clean_media_cache_after">
+        <observer name="sr_cloudflare_flush_all_on_clean_media"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="clean_catalog_images_cache_after">
+        <observer name="sr_cloudflare_flush_all_on_clean_catalog_images"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="adminhtml_cache_refresh_type">
+        <observer name="sr_cloudflare_flush_all_on_refresh_type"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+    <event name="assign_theme_to_stores_after">
+        <observer name="sr_cloudflare_flush_all_on_assign_theme"
+                  instance="SR\Cloudflare\Observer\FlushAllCacheObserver"/>
+    </event>
+</config>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -64,5 +64,11 @@
                 disabled="false" />
     </type>
     <!-- end definitions for MirasvitLabel -->
+
+    <type name="Magento\Framework\Controller\ResultInterface">
+        <plugin name="sr_cloudflare_add_cache_tag_header"
+                type="SR\Cloudflare\Plugin\AddCacheTagHeader"
+                sortOrder="-10"/>
+    </type>
     <!-- ========== end: Plugin definitions ========== -->
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -7,6 +7,8 @@
     <module name="SR_Cloudflare" setup_version="0.0.1">
         <sequence>
             <module name="SR_Base"/>
+            <module name="Magento_PageCache"/>
+            <module name="SR_Gateway"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
This pull request introduces a comprehensive Cloudflare cache integration for Magento, enabling tag-based and site-wide cache purging, configurable through the admin panel. It adds a new configuration group, observers for cache-related events, a Cloudflare API client, and a specialized logger for cache operations. The integration ensures cache tags are properly managed and purged, improving cache control and debugging capabilities.

**Cloudflare Cache Integration**

* Added `CacheConfig` class to manage Cloudflare cache settings, including zone ID, API token, API URL, and site-wide tag logic.
* Introduced `CloudflareClient` for tag-based, site-wide, and URL-based cache purging using the Cloudflare API.

**Event Observers for Cache Purging**

* Registered `PurgeByTags` and `FlushAllCacheObserver` to handle various cache-related Magento events, triggering Cloudflare cache purges as needed.
* Implemented observer classes for tag-based and full cache purging, ensuring only configured sites perform cache operations. [[1]](diffhunk://#diff-6b9d2dc05d1ff9644c1e242196604caca7284047641072bfe73d2b51016dd295R1-R40) [[2]](diffhunk://#diff-76656a422b735e4e0f0b9a46004c640412538562721630d3faf96334c470dd8fR1-R28)

**Cache Tag Management**

* Added `AddCacheTagHeader` plugin to prepend a site-wide tag to cache headers, enabling full-cache flush by tag without affecting image transformations. [[1]](diffhunk://#diff-81c3c173ac14394a4e412750b198e746b320af32c7c6fcabdeee969aa2ea2f41R1-R55) [[2]](diffhunk://#diff-5ef2f9220fe36cf549e279f349d37cc4f006b32763ffa36edd55d96f7446c596R67-R72)

**Configuration and Logging Enhancements**

* Introduced new admin configuration group for Cloudflare cache, including enable/disable, zone ID, API token, debug flag, and default values. [[1]](diffhunk://#diff-89223417b0d8b4f3be81bd4caf5573ad94c01df7d6e897cb48352e7c6204af25R34-R71) [[2]](diffhunk://#diff-3bf05ed19b66e6338063bab879891ccbe11ba078352dec2a9ec57ec37bff15bbR14-R19)
* Added specialized file logger for cache operations, writing debug logs to `var/log/srcloudflarecache.log` and reading flags from the cache config group. [[1]](diffhunk://#diff-69f0e5fbcedc2d20af49e14f522a3f37b803132110d0857df146a81332962a3bR1-R48) [[2]](diffhunk://#diff-093a1e43a11122404c853506b7ca4f661e18dd4f6557ec3089cad8ceae34a606R18-R82)

**Module Dependencies**

* Updated module dependencies to require `Magento_PageCache` and `SR_Gateway` for proper operation.